### PR TITLE
mediascanner: handle DATE tag

### DIFF
--- a/media/libstagefright/StagefrightMediaScanner.cpp
+++ b/media/libstagefright/StagefrightMediaScanner.cpp
@@ -185,6 +185,7 @@ MediaScanResult StagefrightMediaScanner::processFileInternal(
         { "genre", METADATA_KEY_GENRE },
         { "title", METADATA_KEY_TITLE },
         { "year", METADATA_KEY_YEAR },
+        { "date", METADATA_KEY_DATE },
         { "duration", METADATA_KEY_DURATION },
         { "writer", METADATA_KEY_WRITER },
         { "compilation", METADATA_KEY_COMPILATION },


### PR DESCRIPTION
Allow passing DATE tag to MediaScanner in order to use it to retrieve the year, if YEAR tag isn't
present (see http://review.cyanogenmod.org/#/c/101467)

Change-Id: I928177e5473262a45b1041a58f381a00d67e2995
Signed-off-by: Jorge Ruesga <jorge@ruesga.com>